### PR TITLE
[MsgHook] Add way to get request headers on hooks

### DIFF
--- a/plugins/MsgHook/0MsgHook.plugin.js
+++ b/plugins/MsgHook/0MsgHook.plugin.js
@@ -2,10 +2,10 @@
  * @name MsgHook
  * @author Adam Thompson-Sharpe
  * @description Run code when messages are sent or edited.
- * @version 0.2.0
+ * @version 0.3.0
  * @authorId 309628148201553920
  * @source https://github.com/MysteryBlokHed/BetterDiscordPlugins/blob/master/plugins/MsgHook
- * @updateUrl https://raw.githubusercontent.com/MysteryBlokHed/BetterDiscordPlugins/master/plugins/MsgHook/msghook.plugin.js
+ * @updateUrl https://raw.githubusercontent.com/MysteryBlokHed/BetterDiscordPlugins/master/plugins/MsgHook/MsgHook.plugin.js
  */
 module.exports = class MsgHook {
   constructor() {

--- a/plugins/MsgHook/0MsgHook.plugin.ts
+++ b/plugins/MsgHook/0MsgHook.plugin.ts
@@ -2,10 +2,10 @@
  * @name MsgHook
  * @author Adam Thompson-Sharpe
  * @description Run code when messages are sent or edited.
- * @version 0.2.0
+ * @version 0.3.0
  * @authorId 309628148201553920
  * @source https://github.com/MysteryBlokHed/BetterDiscordPlugins/blob/master/plugins/MsgHook
- * @updateUrl https://raw.githubusercontent.com/MysteryBlokHed/BetterDiscordPlugins/master/plugins/MsgHook/msghook.plugin.js
+ * @updateUrl https://raw.githubusercontent.com/MysteryBlokHed/BetterDiscordPlugins/master/plugins/MsgHook/MsgHook.plugin.js
  */
 module.exports = class MsgHook {
   /** List of hooks to run */

--- a/plugins/MsgHook/0MsgHook.plugin.ts
+++ b/plugins/MsgHook/0MsgHook.plugin.ts
@@ -11,6 +11,20 @@ module.exports = class MsgHook {
   /** List of hooks to run */
   hooks: HookFunction[] = []
 
+  /** Returns whether or not a request should be noticed by MsgHook */
+  isMessageRequest(method: string, url: string): boolean {
+    /** Request URL to send a message. Last updated for v9 API */
+    const sendMessage =
+      /^https:\/\/discord.com\/api\/v\d+\/channels\/\d{18}\/messages$/
+    /** Request URL to edit a message. Last update for v9 API */
+    const editMessage =
+      /^https:\/\/discord.com\/api\/v\d+\/channels\/\d{18}\/messages\/\d{18}$/
+
+    if (!['POST', 'PATCH'].includes(method)) return false
+    if (url.match(sendMessage) || url.match(editMessage)) return true
+    return false
+  }
+
   load() {
     // Add MsgHook object to window
     ;(window as MsgHookWindow).MsgHook = {
@@ -18,7 +32,43 @@ module.exports = class MsgHook {
       addHook: (hook) => this.hooks.push(hook),
     }
 
-    const handler: ProxyHandler<
+    /**
+     * Handle `XMLHttpRequest.prototype.setRequestHeader`
+     * This Proxy's job is just to add the set headers to an object so that they may be accessed later.
+     * This helps if you're trying to do something that needs an authorization token,
+     * which is set in the request headers.
+     */
+    const setHeaderHandler: ProxyHandler<
+      (name: string, value: string) => void
+    > = {
+      apply: (target, thisArg, args) => {
+        try {
+          // Check if request is message-related
+          if (
+            thisArg.__sentry_xhr__ &&
+            this.isMessageRequest(
+              thisArg.__sentry_xhr__.method,
+              thisArg.__sentry_xhr__.url
+            )
+          ) {
+            // Create a new object called requestHeaders and add each header to it
+            // The headers are later added to the MsgHookEvent headers property
+            if (!thisArg.requestHeaders) thisArg.requestHeaders = {}
+            thisArg.requestHeaders[args[0]] = args[1]
+          }
+        } catch {}
+
+        target.apply(thisArg, args)
+      },
+    }
+
+    XMLHttpRequest.prototype.setRequestHeader = new Proxy(
+      XMLHttpRequest.prototype.setRequestHeader,
+      setHeaderHandler
+    )
+
+    /** Handle `XMLHttpRequest.prototype.send` */
+    const sendHandler: ProxyHandler<
       (body?: Document | XMLHttpRequestBodyInit | null | undefined) => void
     > = {
       apply: (
@@ -28,6 +78,16 @@ module.exports = class MsgHook {
       ) => {
         if ((window as MsgHookWindow).MsgHook.enabled) {
           try {
+            // Check if the request is message-related and exit if it isn't
+            if (
+              !thisArg.__sentry_xhr__ ||
+              !this.isMessageRequest(
+                thisArg.__sentry_xhr__.method,
+                thisArg.__sentry_xhr__.url
+              )
+            )
+              throw Error
+
             let json = JSON.parse(args[0] as string) as MessageJson
 
             // This really ugly ternary just means use MessageType.Send on POST,
@@ -77,6 +137,7 @@ module.exports = class MsgHook {
                 type: method,
                 msg: json.content,
                 id: id,
+                headers: thisArg.requestHeaders,
                 hasCommand(command) {
                   if (this.msg.startsWith(command + ' ')) {
                     return this.msg.replace(new RegExp(`^${command} `), '')
@@ -96,7 +157,7 @@ module.exports = class MsgHook {
 
     XMLHttpRequest.prototype.send = new Proxy(
       XMLHttpRequest.prototype.send,
-      handler
+      sendHandler
     )
   }
 
@@ -119,6 +180,8 @@ interface MsgHookEvent {
    * that already had a hook run was edited.
    */
   id: string | Promise<string>
+  /** The request headers */
+  headers: { [name: string]: string }
   /**
    * Check if a string begins with the given text.
    * If it does, then return the string without that text.

--- a/plugins/MsgHook/CHANGELOG.md
+++ b/plugins/MsgHook/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelogs are different for each plugin.
 
+## 0.3.0
+
+### Added
+
+- Added a way to get the request headers from a hook
+
 ## 0.2.0
 
 ### Added

--- a/plugins/MsgHook/README.md
+++ b/plugins/MsgHook/README.md
@@ -99,6 +99,17 @@ is either a string without the command, or nothing.
 If the string does not have the command, there's nothing to be removed,
 so `e.msg` can be used directly instead.
 
+### Accessing request headers
+
+The headers of the request are also available as `e.headers`.
+This can be useful if you need to use the user's authorization for another request,
+such as to send an additional message or to edit another one.
+Here's an example to log the Authorization header:
+
+```javascript
+window.MsgHook.addHook((e) => console.log(e.headers.Authorization))
+```
+
 ### Block Letters
 
 Here's a hook that converts letters to the `regional_indicator` versions


### PR DESCRIPTION
Adds an `e.headers` property to access the request headers. This is useful if you need to get the Authorization header to perform another action with the Discord API.